### PR TITLE
Add genotype variables query to dictionary object

### DIFF
--- a/PicSureBdcAdapter/PicSureDictionary.py
+++ b/PicSureBdcAdapter/PicSureDictionary.py
@@ -33,14 +33,14 @@ class PicSureDictionary:
     def genotype_annotations(self):
         query = {"query":""}
         results = json.loads(self._apiObj.search(self.resourceUUID, json.dumps(query)))
-        vars = list()
-        for variable, info in results['results']['info'].items():
-            record = info.copy()
-            record['genomic_annotation'] = variable
+        annotations = list()
+        for annotation, annotation_value in results['results']['info'].items():
+            record = annotation_value.copy()
+            record['genomic_annotation'] = annotation
             record['description'] = re.sub("^\"|\"$", "", record['description'].replace("Description=",""))
             record['values'] = ", ".join(record['values'])
-            vars.append(record)
-        df = pd.DataFrame.from_records(vars)
+            annotations.append(record)
+        df = pd.DataFrame.from_records(annotations)
         df = df.reindex(columns=['genomic_annotation', 'description', 'values', 'continuous'])
         return df
     genotype_annotations.__doc__ = """

--- a/PicSureBdcAdapter/PicSureDictionary.py
+++ b/PicSureBdcAdapter/PicSureDictionary.py
@@ -21,10 +21,14 @@ class PicSureDictionary:
         self._included_studies = list(map(stripSlashes, filter(r.match, self._profile_queryScopes)))
 
     def help(self):
-        print("""
-            .find()                 Lists all data dictionary entries
-            .find(search_string)    Lists matching data dictionary entries
-        """)
+        print ("""
+            [HELP] PicSureBdcAdapter.Adapter(url, token).useDictionary().dictionary()
+            %s
+            %s
+        """ % (
+            self.find.__doc__, 
+            self.genotype_annotations.__doc__, 
+        ))
 
     def genotype_annotations(self):
         query = {"query":""}
@@ -39,6 +43,8 @@ class PicSureDictionary:
         df = pd.DataFrame.from_records(vars)
         df = df.reindex(columns=['genomic_annotation', 'description', 'values', 'continuous'])
         return df
+    genotype_annotations.__doc__ = """
+    .genotype_annotations() Lists all genotypic annotations available to use as filters"""
 
     def find(self, term=None):
         if term == None:
@@ -50,4 +56,6 @@ class PicSureDictionary:
             return result['result']['studyId'].split('.')[0] in self._included_studies
         results['results']['searchResults'] = list(filter(isInScope, results['results']['searchResults']))
         return  DictionaryResult(results)
-
+    find.__doc__ = """
+    .find()                 Lists all phenotypic data dictionary entries
+    .find(search_string)    Lists all phenotypic data dictionary entries that match the search string"""

--- a/PicSureBdcAdapter/PicSureDictionary.py
+++ b/PicSureBdcAdapter/PicSureDictionary.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import json
 import re
+import pandas as pd
 from .DictionaryResult import DictionaryResult
 
 class PicSureDictionary:
@@ -24,6 +25,20 @@ class PicSureDictionary:
             .find()                 Lists all data dictionary entries
             .find(search_string)    Lists matching data dictionary entries
         """)
+
+    def genotype_annotations(self):
+        query = {"query":""}
+        results = json.loads(self._apiObj.search(self.resourceUUID, json.dumps(query)))
+        vars = list()
+        for variable, info in results['results']['info'].items():
+            record = info.copy()
+            record['genomic_annotation'] = variable
+            record['description'] = re.sub("^\"|\"$", "", record['description'].replace("Description=",""))
+            record['values'] = ", ".join(record['values'])
+            vars.append(record)
+        df = pd.DataFrame.from_records(list(vars))
+        df = df.reindex(columns=['genomic_annotation', 'description', 'values', 'continuous'])
+        return df
 
     def find(self, term=None):
         if term == None:

--- a/PicSureBdcAdapter/PicSureDictionary.py
+++ b/PicSureBdcAdapter/PicSureDictionary.py
@@ -36,7 +36,7 @@ class PicSureDictionary:
             record['description'] = re.sub("^\"|\"$", "", record['description'].replace("Description=",""))
             record['values'] = ", ".join(record['values'])
             vars.append(record)
-        df = pd.DataFrame.from_records(list(vars))
+        df = pd.DataFrame.from_records(vars)
         df = df.reindex(columns=['genomic_annotation', 'description', 'values', 'continuous'])
         return df
 


### PR DESCRIPTION
Reaches out to the resource with an empty query to get phenotype and genotype information, then maps that return value into a data frame. Useful on auth and open data resources only. Column names per Simran. 

<img width="1084" alt="Screen Shot 2022-06-08 at 12 32 36 PM" src="https://user-images.githubusercontent.com/21109191/172670037-841cdf76-ec5d-4dd7-b24c-c39a64e3c791.png">
